### PR TITLE
full set of aka's for completeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This code implements a DXE driver for EDK2/Tianocore that allows UEFI
 drivers built for x86_64 aka X64 aka amd64 to be executed on 64-bit
-ARM systems (aka AArch64)
+ARM systems aka AArch64 aka ARMv8 aka arm64.
 
 The prerequisites are not fully upstream, and may never be, but the
 delta is quite small. They can be found here:


### PR DESCRIPTION
ARMv8 systems go by many names, including 64-bit ARM, arm64, and aarch64. Include all of them in the aka list at the beginning. closes #4.