### PR TITLE
x86: fix pcmpestrm and pcmpistrm

### DIFF
--- a/qemu/target-i386/ops_sse.h
+++ b/qemu/target-i386/ops_sse.h
@@ -1996,10 +1996,10 @@ void glue(helper_pcmpestrm, SUFFIX) (Reg *d, Reg *s, uint32_t ctrl)
 
     if ((ctrl >> 6) & 1) {
         if (ctrl & 1)
-            for (i = 0; i <= 8; i--, res >>= 1)
+            for (i = 0; i < 8; i++, res >>= 1)
                 d->W(i) = (res & 1) ? ~0 : 0;
         else
-            for (i = 0; i <= 16; i--, res >>= 1)
+            for (i = 0; i < 16; i++, res >>= 1)
                 d->B(i) = (res & 1) ? ~0 : 0;
     } else {
         d->Q(1) = 0;
@@ -2028,10 +2028,10 @@ void glue(helper_pcmpistrm, SUFFIX) (Reg *d, Reg *s, uint32_t ctrl)
 
     if ((ctrl >> 6) & 1) {
         if (ctrl & 1)
-            for (i = 0; i <= 8; i--, res >>= 1)
+            for (i = 0; i < 8; i++, res >>= 1)
                 d->W(i) = (res & 1) ? ~0 : 0;
         else
-            for (i = 0; i <= 16; i--, res >>= 1)
+            for (i = 0; i < 16; i++, res >>= 1)
                 d->B(i) = (res & 1) ? ~0 : 0;
     } else {
         d->Q(1) = 0;


### PR DESCRIPTION
Fix obvious typos (decrement and off-by-one error) in pcmpestrm and pcmpistrm
which resulted in infinite loop. Reported by Frank Mehnert,
spotted also by Coverity (bug 84752853).

Reported-by: Frank Mehnert <frank.mehnert@oracle.com>
Signed-off-by: Blue Swirl <blauwirbel@gmail.com>

Fix for #9 